### PR TITLE
Support rustls-tls in addition to default-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ build = false
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-reqwest = { version = "0.11.18", features = ['blocking','json'] }
+reqwest = { version = "0.12", features = ['blocking','json'], default-features = false }
 serde_json = "1.0.102"
 serde = { version = "1.0.171", features = ["derive"] }
+
+[features]
+default = ['reqwest/default']
+rustls-tls = ['reqwest/rustls-tls']


### PR DESCRIPTION
I'd like to add support for using rustls and ring instead of having a dependency on openssl when using the palm-api.